### PR TITLE
Update Style/MethodCallWithArgsParentheses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,7 +33,10 @@ Metrics/PerceivedComplexity:
 Naming/VariableNumber:
   Enabled: false
 Style/MethodCallWithArgsParentheses:
+  Enabled: true
   EnforcedStyle: omit_parentheses
+  AllowParenthesesInMultilineCall: true
+  AllowParenthesesInCamelCaseMethod: true
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses
 Style/RescueModifier:

--- a/google-style.gemspec
+++ b/google-style.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.3.8"
 
-  gem.add_dependency "rubocop", "~> 0.62.0"
+  gem.add_dependency "rubocop", "~> 0.64.0"
   gem.add_dependency "rubocop-rspec", "~> 1.32"
   gem.add_development_dependency "bundler", "~> 1.17"
   gem.add_development_dependency "rake", "~> 12.3"


### PR DESCRIPTION
Add options for using parentheses in methods calls. These options are available in rubocop to 0.64, so update the dependency to that version.