### PR TITLE
Update ruby version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+AllCops:
+  TargetRubyVersion: 2.2
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
 Layout/EmptyLines: # for the extra line between copyright and code

--- a/google-style.gemspec
+++ b/google-style.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.files         = ["CONTRIBUTING.md", "CODE_OF_CONDUCT.md", "LICENSE"]
 
-  gem.required_ruby_version = ">= 2.3.8"
+  gem.required_ruby_version = ">= 2.2.0"
 
   gem.add_dependency "rubocop", "~> 0.62.0"
   gem.add_dependency "rubocop-rspec", "~> 1.32"


### PR DESCRIPTION
Specify the TargetRubyVersion, make it match required_ruby_version.

This is needed to make `rubocop` pass on the project.