### PR TITLE
Release ruby-style 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 0.2.0 / 2019-03-13
+
+* Set TargetRubyVersion to 2.3 
+* Disable Style/FrozenStringLiteralComment
+* Enable Metrics/ClassLength
+
 ### 0.1.0 / 2019-03-07
 
 * Initial release

--- a/google-style.gemspec
+++ b/google-style.gemspec
@@ -14,7 +14,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-style"
-  gem.version       = "0.1.0"
+  gem.version       = "0.2.0"
 
   gem.authors       = ["Graham Paye"]
   gem.email         = ["paye@google.com"]


### PR DESCRIPTION
* Set TargetRubyVersion to 2.3 
* Disable Style/FrozenStringLiteralComment
* Enable Metrics/ClassLength

This pull request was generated using releasetool.