### PR TITLE
A few updates following discussions on ruby-docs-samples

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -36,7 +36,7 @@ task :release, :tag do |_t, args|
     sh "bundle exec rake build"
   end
 
-  path_to_be_pushed = "pkg/#{version}.gem"
+  path_to_be_pushed = "pkg/google-style-#{version}.gem"
   raise "Cannot build google-style for version #{version}" unless File.file? path_to_be_pushed
   begin
     ::Gems.push File.new(path_to_be_pushed)

--- a/google-style.gemspec
+++ b/google-style.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.files         = ["CONTRIBUTING.md", "CODE_OF_CONDUCT.md", "LICENSE",
                        "README.md", "google-style.yml"]
 
-  gem.required_ruby_version = ">= 2.2.0"
+  gem.required_ruby_version = ">= 2.3.0"
 
   gem.add_dependency "rubocop", "~> 0.64.0"
   gem.add_development_dependency "bundler", "~> 1.17"

--- a/google-style.yml
+++ b/google-style.yml
@@ -35,8 +35,6 @@ Metrics/PerceivedComplexity:
   Max: 10
 Naming/VariableNumber:
   Enabled: false
-Style/BlockDelimiters:
-  EnforcedStyle: braces_for_chaining
 Style/EmptyMethod:
   EnforcedStyle: expanded
 Style/FrozenStringLiteralComment:

--- a/google-style.yml
+++ b/google-style.yml
@@ -53,5 +53,9 @@ Style/RescueModifier:
   Enabled: false
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+Style/SymbolArray:
+  EnforcedStyle: brackets
 Style/TrivialAccessors:
   Enabled: false
+Style/WordArray:
+  EnforcedStyle: brackets

--- a/google-style.yml
+++ b/google-style.yml
@@ -35,6 +35,10 @@ Metrics/PerceivedComplexity:
   Max: 10
 Naming/VariableNumber:
   Enabled: false
+Style/BlockDelimiters:
+  EnforcedStyle: braces_for_chaining
+Style/EmptyMethod:
+  EnforcedStyle: expanded
 Style/FrozenStringLiteralComment:
   Enabled: false
 Style/MethodCallWithArgsParentheses:
@@ -42,6 +46,7 @@ Style/MethodCallWithArgsParentheses:
   EnforcedStyle: omit_parentheses
   AllowParenthesesInMultilineCall: true
   AllowParenthesesInCamelCaseMethod: true
+  AllowParenthesesInChaining: true
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses
 Style/RescueModifier:


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/ruby-docs-samples/pull/408 for referenced discussion

* Enforce expaned for Style/EmptyMethod
* Enforce braces_for_chaining for Style/BlockDelimiters
* Allow parenthesis in chaining for Style/MethodCallWithArgsParentheses

* Would also be curious to hear everyone's thoughts on:
  - Enforce require_no_parentheses_except_multiline for Style/MethodDefParentheses
  - Enforce brackets for Style/SymbolArray and Style/WordArray (so we get `[:symbol, :other_symbol]` instead of `%i[foo bar baz]`