### PR TITLE
Release ruby-style 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 0.3.0 / 2019-05-06
+
+* Enforce expanded for Style/EmptyMethod
+* Allow parentheses in chaining for Style/MethodCallWithArgsParentheses
+* Enforce brackets for Style/WordArray and Style/SymbolArray
+
 ### 0.2.0 / 2019-03-13
 
 * Set TargetRubyVersion to 2.3 

--- a/google-style.gemspec
+++ b/google-style.gemspec
@@ -14,7 +14,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-style"
-  gem.version       = "0.2.0"
+  gem.version       = "0.3.0"
 
   gem.authors       = ["Graham Paye"]
   gem.email         = ["paye@google.com"]


### PR DESCRIPTION
* Enforce expanded for Style/EmptyMethod
* Allow parentheses in chaining for Style/MethodCallWithArgsParentheses
* Enforce brackets for Style/WordArray and Style/SymbolArray

This pull request was generated using releasetool.