### PR TITLE
Release ruby-style 1.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 1.24.0 / 2019-08-08
+
+* set required ruby version to 2.4
+* set rubocop dependency to ~> 0.74.0
+
 ### 0.3.1 / 2019-06-12
 
 * Fix file permissions


### PR DESCRIPTION
* set required ruby version to 2.4
* set rubocop dependency to ~> 0.74.0

<details><summary>Commits since previous release</summary><pre><code>commit d9c276f3b286f4a5225439222a86b1d11a5622c6
Author: Graham Paye <paye@google.com>
Date:   Thu Aug 8 14:26:57 2019 -0700

    bump required ruby version to 2.4 (#17)
    
    * bump required ruby version to 2.4
    * bump rubocop dependency to ~> 0.74.0

commit 0eb4adad7e98cc4018ba83c0b1564691a28131af
Author: Daniel Azuma <dazuma@google.com>
Date:   Thu Jun 13 13:14:39 2019 -0700

    Bump version to 0.3.1 (#16)
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/CHANGELOG.md b/CHANGELOG.md
index 03700f4..b81f8b3 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.3.1 / 2019-06-12
+
+* Fix file permissions
+
 ### 0.3.0 / 2019-05-06
 
 * Enforce expanded for Style/EmptyMethod
diff --git a/README.md b/README.md
index 731af02..69105b8 100644
--- a/README.md
+++ b/README.md
@@ -51,11 +51,12 @@ This library is licensed under Apache 2.0. Full license text is available in
 
 ## Supported Ruby Versions
 
-These libraries are currently supported on Ruby 2.3+.
+These libraries are currently supported on Ruby 2.4+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.3
-and later. Older versions of Ruby _may_ still work, but are unsupported and not
-recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
-about the Ruby support schedule.
+in security maintenance, and not end of life. Currently, this means Ruby 2.4
+and later. Starting with Ruby 2.4, minor releases of the google-style gem under
+`1.x.x` will correspond with the required Ruby version, with `1.24.x` requiring
+Ruby 2.4.
+See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
diff --git a/google-style-1.24.0.gem b/google-style-1.24.0.gem
new file mode 100644
index 0000000..adf25c9
Binary files /dev/null and b/google-style-1.24.0.gem differ
diff --git a/google-style.gemspec b/google-style.gemspec
index 56ad6be..7b8ea7a 100644
--- a/google-style.gemspec
+++ b/google-style.gemspec
@@ -14,7 +14,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-style"
-  gem.version       = "0.3.0"
+  gem.version       = "1.24.0"
 
   gem.authors       = ["Graham Paye"]
   gem.email         = ["paye@google.com"]
@@ -26,9 +26,9 @@ Gem::Specification.new do |gem|
   gem.files         = ["CONTRIBUTING.md", "CODE_OF_CONDUCT.md", "LICENSE",
                        "README.md", "google-style.yml"]
 
-  gem.required_ruby_version = ">= 2.3.0"
+  gem.required_ruby_version = ">= 2.4.0"
 
-  gem.add_dependency "rubocop", "~> 0.64.0"
-  gem.add_development_dependency "bundler", "~> 1.17"
+  gem.add_dependency "rubocop", "~> 0.74.0"
+  gem.add_development_dependency "bundler", "~> 2.0"
   gem.add_development_dependency "rake", "~> 12.3"
 end
diff --git a/google-style.yml b/google-style.yml
index 44452df..3404f91 100644
--- a/google-style.yml
+++ b/google-style.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 Layout/AlignHash:
   EnforcedHashRocketStyle: table
   EnforcedColonStyle: table

```

</details>

This pull request was generated using releasetool.