### PR TITLE
Disable NumericLiterals in default style

### DIFF
--- a/google-style.yml
+++ b/google-style.yml
@@ -47,6 +47,8 @@ Style/MethodCallWithArgsParentheses:
   AllowParenthesesInChaining: true
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses
+Style/NumericLiterals:
+  Enabled: false
 Style/RescueModifier:
   Enabled: false
 Style/StringLiterals:


### PR DESCRIPTION
This rule enforces numbers to be 10_000 instead of 10000.