### PR TITLE
Release ruby-style 1.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 1.25.0 / 2021-01-27
+
+* chore: add CODEOWNERS (#24)
+* bump rubocop version to latest, set min ruby to 2.5, enable new cops (#27)
+
 ### 1.24.0 / 2019-08-08
 
 * Set required ruby version to 2.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ### 1.25.0 / 2021-01-27
 
-* chore: add CODEOWNERS (#24)
-* bump rubocop version to latest, set min ruby to 2.5, enable new cops (#27)
+* pin rubocop version to 1.x, set min ruby to 2.5, enable new cops
 
 ### 1.24.0 / 2019-08-08
 

--- a/google-style.gemspec
+++ b/google-style.gemspec
@@ -14,7 +14,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-style"
-  gem.version       = "1.24.0"
+  gem.version       = "1.25.0"
 
   gem.authors       = ["Graham Paye"]
   gem.email         = ["paye@google.com"]


### PR DESCRIPTION
* chore: add CODEOWNERS (#24)
* bump rubocop version to latest, set min ruby to 2.5, enable new cops (#27)

This pull request was generated using releasetool.