### PR TITLE
fix: Fix crash on extension checking and eliminate new cop warning

### DIFF
--- a/google-style.yml
+++ b/google-style.yml
@@ -1,11 +1,11 @@
 # Copyright 2019 Google LLC
-
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-
+#
 #     https://www.apache.org/licenses/LICENSE-2.0
-
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 AllCops:
-  SuggestExtensions: true
+  NewCops: disable
+  SuggestExtensions: false
   TargetRubyVersion: 2.5
 
 Layout/EmptyLineAfterGuardClause:


### PR DESCRIPTION
* `true` is actually not a valid value for `SuggestExtensions:` (and results in an exception at the end of a run when checking extensions). I set it to `false` (which _is_ a valid value) instead, to eliminate the suggestion messages by default.
* Explicitly set `NewCops: disable` to eliminate the warning message that shows new cops that haven't been explicitly enabled or disabled.