### PR TITLE
Release ruby-style 1.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 1.25.1 / 2021-02-09
+
+* Add rubocop 1.9 cops and disable a few others
+* Fix crash on extension checking, and eliminate new cop warning
+
 ### 1.25.0 / 2021-01-27
 
 * pin rubocop version to 1.x, set min ruby to 2.5, enable new cops

--- a/google-style.gemspec
+++ b/google-style.gemspec
@@ -14,7 +14,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-style"
-  gem.version       = "1.25.0"
+  gem.version       = "1.25.1"
 
   gem.authors       = ["Graham Paye"]
   gem.email         = ["paye@google.com"]


### PR DESCRIPTION
* Add rubocop 1.9 cops and disable a few others
* Fix crash on extension checking, and eliminate new cop warning

<details><summary>Commits since previous release</summary><pre><code>commit d79c6117fd1dbe253500fcca473071aa4feb545b
Author: Daniel Azuma <dazuma@google.com>
Date:   Mon Feb 8 16:00:30 2021 -0800

    fix: Add rubocop 1.9 cops and disable a few others

commit 5fd0d420c460b9218154ddc956f63ff88b126ed4
Author: Daniel Azuma <dazuma@google.com>
Date:   Fri Jan 29 13:33:21 2021 -0800

    fix: Fix crash on extension checking, and eliminate new cop warning
</code></pre></details>

This pull request was generated using releasetool.