### PR TITLE
fix: Updates for Rubocop 1.31

### DIFF
--- a/google-style.gemspec
+++ b/google-style.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.6.0"
 
-  gem.add_dependency "rubocop", "~> 1.30"
+  gem.add_dependency "rubocop", "~> 1.31"
 end

--- a/google-style.yml
+++ b/google-style.yml
@@ -17,10 +17,6 @@ AllCops:
   SuggestExtensions: false
   TargetRubyVersion: 2.6
 
-# Added in Rubocop 1.10
-Gemspec/DateAssignment:
-  Enabled: true
-
 # Added in Rubocop 1.30
 Gemspec/DeprecatedAttributeAssignment:
   Enabled: true
@@ -41,6 +37,14 @@ Layout/EmptyLines:
 # our code adheres to the "table" style, but we do not want to enforce it.
 Layout/HashAlignment:
   Enabled: false
+
+# Added in Rubocop 1.31
+Layout/LineContinuationLeadingSpace:
+  Enabled: true
+
+# Added in Rubocop 1.31
+Layout/LineContinuationSpacing:
+  Enabled: true
 
 # Added in Rubocop 1.18
 Layout/LineEndStringConcatenationIndentation:
@@ -64,6 +68,10 @@ Lint/AmbiguousOperatorPrecedence:
 
 # Added in Rubocop 1.19
 Lint/AmbiguousRange:
+  Enabled: true
+
+# Added in Rubocop 1.31
+Lint/ConstantOverwrittenInRescue:
   Enabled: true
 
 # Added in Rubocop 1.8
@@ -100,6 +108,10 @@ Lint/LambdaWithoutLiteralBlock:
 
 # Added in Rubocop 1.2
 Lint/NoReturnInBeginEndBlocks:
+  Enabled: true
+
+# Added in Rubocop 1.31
+Lint/NonAtomicFileOperation:
   Enabled: true
 
 # Added in Rubocop 1.9


### PR DESCRIPTION
Unfortunately, Rubocop 1.31 introduced a breaking change by erroring out when referencing `Gemspec/DateAssignment` in a config. So we'll have to update google-style past that point.