### PR TITLE
chore: use the release-please GitHub App for creating releases, tagging, and triggering

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,0 +1,7 @@
+bumpMinorPreMajor: true
+handleGHRelease: true
+manifest: true
+monorepoTags: true
+packageName: google-style
+primaryBranch: main
+releaseType: ruby-yoshi

--- a/.github/release-trigger.yml
+++ b/.github/release-trigger.yml
@@ -1,0 +1,1 @@
+enabled: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,7 +1,5 @@
 name: Release-Please
 on:
-  schedule:
-    - cron: '37 10 * * *'
   workflow_dispatch:
     inputs:
       gem:


### PR DESCRIPTION
Currently, this repository runs the release-please command line from a custom GitHub Action (which runs nightly on a cron, and can be triggered manually), and relies on the Kokoro-based tagger to tag releases and trigger the release job.

This PR disables the release-please GitHub Action cron, and instead configures the App to run against the existing manifest. It also causes the GitHub App tagger and trigger to run. This should make the Kokoro tagger unnecessary for Ruby.

The release-please GitHub Action itself will remain, and we will still be able to trigger it manually. (We use this to retrigger failed releases, and/or release versions other than what release-please calculates.)

This PR should be merged about the same time as Ruby is disabled in the Kokoro tagger (and at the same time as similar PRs are merged for all other Ruby repositories) to avoid the errors that could take place if both the GitHub App and Kokoro try to process the same release. @dazuma will coordinate merging; please do not merge without consulting him first.